### PR TITLE
chore(deps): upgrade github actions to node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,23 @@ on:
 permissions:
     contents: read
 
+env:
+    # oven-sh/setup-bun@v2 still declares node20; force node24 until a native node24 version is released
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
     lint:
         name: Lint & Format
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.7
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: |
                       ~/.bun/install/cache
@@ -47,14 +51,14 @@ jobs:
         name: Type Check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.7
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: |
                       ~/.bun/install/cache
@@ -73,14 +77,14 @@ jobs:
         name: Unit Tests
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.7
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: |
                       ~/.bun/install/cache
@@ -99,14 +103,14 @@ jobs:
         name: Integration Tests
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.7
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: |
                       ~/.bun/install/cache
@@ -125,14 +129,14 @@ jobs:
         name: Build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.7
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: |
                       ~/.bun/install/cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ permissions:
 
 env:
     DRY_RUN: ${{ !(startsWith(github.ref, 'refs/tags/') || inputs.dry-run == 'false') }}
+    # oven-sh/setup-bun@v2 still declares node20; force node24 until a native node24 version is released
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
     build:
@@ -23,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: oven-sh/setup-bun@v2
               with:
@@ -75,7 +77,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Download artifacts
               uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout@v4` → `v5` and `actions/cache@v4` → `v5`, which natively use the Node.js 24 runtime
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` at the workflow `env:` level to cover `oven-sh/setup-bun@v2`, which has no Node.js 24 version yet

Closes #9

## Test plan

- [ ] CI passes on this PR with no Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)