### PR TITLE
fix(hook): plan denied on exit instead of no-op

### DIFF
--- a/app/lib/socket-ipc.test.ts
+++ b/app/lib/socket-ipc.test.ts
@@ -645,7 +645,7 @@ describe('lib socket-ipc', () => {
 
     describe('PlandersonSocketServer.waitForDecision()', () => {
         describe('Client disconnect', () => {
-            test('resolves as error when connected TUI closes without sending decision', async () => {
+            test('resolves as no-op when connected TUI closes without sending decision', async () => {
                 const { PlandersonSocketServer } = await import('./socket-ipc');
                 const socketPath = `/tmp/planderson-test-disconnect-${Date.now()}.sock`;
                 const server = new PlandersonSocketServer(socketPath);
@@ -668,10 +668,7 @@ describe('lib socket-ipc', () => {
                     });
 
                     const result = await server.waitForDecision(5);
-                    expect(result.type).toBe('error');
-                    if (result.type === 'error') {
-                        expect(result.error).toContain('disconnected');
-                    }
+                    expect(result.type).toBe('no-op');
                 } finally {
                     await server.close();
                 }

--- a/app/lib/socket-ipc.ts
+++ b/app/lib/socket-ipc.ts
@@ -13,6 +13,7 @@ export type SocketMessage =
     | { type: 'get_plan' }
     | { type: 'plan'; content: string }
     | { type: 'decision'; decision: 'accept' | 'deny'; message?: string }
+    | { type: 'no-op' }
     | { type: 'error'; error: string };
 
 /**
@@ -234,13 +235,10 @@ export class PlandersonSocketServer {
             // Clear active socket when connection closes
             this.activeSocket = null;
 
-            // Resolve with error only if the TUI had engaged (sent get_plan)
-            // Probe connections that disconnect immediately have sessionEngaged=false
-            if (this.sessionEngaged && this.decisionResolve !== null) {
-                this.decisionResolve({
-                    type: 'error',
-                    error: 'TUI disconnected without sending a decision',
-                });
+            // Any TUI disconnect without a prior decision is a no-op.
+            // This covers crashes before get_plan, crashes after, and signal exits.
+            if (this.decisionResolve !== null) {
+                this.decisionResolve({ type: 'no-op' });
                 this.decisionResolve = null;
             }
             this.sessionEngaged = false;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -82,15 +82,8 @@ export const AppInner: React.FC<AppInnerProps> = ({
     // Signal handlers: Clean shutdown on Ctrl+C (SIGINT) or SIGTERM
     useEffect(() => {
         const handleSignal = (signal: string): void => {
-            try {
-                // Send cancel decision to hook if in socket mode
-                sendDecisionViaSocket(sessionId, socketClient, mode, 'deny', 'Cancelled by user (signal)');
-                logEvent(__filename, sessionId, 'process.signal', signal);
-            } catch (err) {
-                logError(__filename, sessionId, 'signal.errored', err as Error, 'failed to send cancel');
-            } finally {
-                exit();
-            }
+            logEvent(__filename, sessionId, 'process.signal', signal);
+            exit();
         };
 
         // Register signal handlers

--- a/app/src/commands/hook.ts
+++ b/app/src/commands/hook.ts
@@ -199,7 +199,7 @@ const waitForDecisionViaSocket = async function (
     sessionId: string,
     planContent: string,
     timeoutSeconds: number = DEFAULT_TIMEOUT_SECONDS,
-): Promise<PlandersonResponse | 'timeout'> {
+): Promise<PlandersonResponse | 'timeout' | 'no-op'> {
     // Create socket path unique to this run (with env var override for testing)
     const socketId = getSocketId(sessionId);
     const socketPath =
@@ -293,6 +293,9 @@ const waitForDecisionViaSocket = async function (
                 decision: result.decision,
                 message: result.message,
             };
+        } else if (result.type === 'no-op') {
+            logEvent(__filename, sessionId, 'socket.server.noop', 'TUI exited without decision');
+            return 'no-op';
         } else if (result.type === 'error') {
             logError(__filename, sessionId, 'socket.server.errored', new Error(result.error));
 
@@ -385,6 +388,11 @@ const main = async function (): Promise<void> {
 
         // Wait for Planderson decision via Unix socket (blocks until TUI responds)
         const result = await waitForDecisionViaSocket(sessionId, planContent);
+
+        if (result === 'no-op') {
+            logEvent(__filename, sessionId, 'hook.ended', 'behavior=no-op');
+            process.exit(0); // No JSON output = allow in Claude Code
+        }
 
         // Map socket result to hook response
         const { behavior, message } = mapSocketResultToHookResponse(result, DEFAULT_TIMEOUT_SECONDS);

--- a/app/tests/integration/claude-hook/hook-socket-errors.integration.test.ts
+++ b/app/tests/integration/claude-hook/hook-socket-errors.integration.test.ts
@@ -93,10 +93,10 @@ describe('claude-hook hook-socket-errors integration', () => {
             }, 200);
 
             const stdout = await readStream(hookProcess.stdout);
+            // No-op: hook exits without JSON output (empty stdout = allow in Claude Code)
+            if (stdout.trim() === '') return;
             const response = JSON.parse(stdout);
-
-            // Should timeout or return error
-            expect(response.hookSpecificOutput.decision.behavior).toBe('deny');
+            expect(response.hookSpecificOutput.decision.behavior).toBe('allow');
         }, 10000);
 
         test('handles TUI disconnecting during plan transmission', async () => {
@@ -129,10 +129,46 @@ describe('claude-hook hook-socket-errors integration', () => {
             });
 
             const stdout = await readStream(hookProcess.stdout);
+            // No-op: hook exits without JSON output (empty stdout = allow in Claude Code)
+            if (stdout.trim() === '') return;
             const response = JSON.parse(stdout);
+            expect(response.hookSpecificOutput.decision.behavior).toBe('allow');
+        }, 10000);
 
-            // Should handle gracefully
-            expect(response.hookSpecificOutput.decision.behavior).toBe('deny');
+        test('handles TUI exiting via signal (no decision sent)', async () => {
+            const { path: TEST_SOCKET_PATH } = useTestSocket('hook-socket-errors');
+            const hookInput = {
+                tool_name: 'ExitPlanMode',
+                tool_input: { plan: 'Test plan' },
+                hook_event_name: 'PermissionRequest',
+            };
+
+            const hookProcess = spawnHook({
+                PLANDERSON_SOCKET_PATH: TEST_SOCKET_PATH,
+                PLANDERSON_TIMEOUT_SECONDS: '3',
+            });
+
+            hookProcess.stdin.write(JSON.stringify(hookInput));
+            hookProcess.stdin.end();
+
+            // Connect, get plan, then destroy without sending decision (simulates signal exit)
+            await waitForSocket(TEST_SOCKET_PATH);
+            const client = net.connect(TEST_SOCKET_PATH);
+            client.on('connect', () => {
+                client.write(`${JSON.stringify({ type: 'get_plan' })}\n`);
+                client.on('data', () => {
+                    client.destroy();
+                });
+            });
+            client.on('error', () => {
+                // Suppress error
+            });
+
+            const stdout = await readStream(hookProcess.stdout);
+            // No-op: hook exits without JSON output (empty stdout = allow in Claude Code)
+            if (stdout.trim() === '') return;
+            const response = JSON.parse(stdout);
+            expect(response.hookSpecificOutput.decision.behavior).toBe('allow');
         }, 10000);
     });
 

--- a/app/tests/integration/infrastructure/socket.integration.test.ts
+++ b/app/tests/integration/infrastructure/socket.integration.test.ts
@@ -221,7 +221,7 @@ describe('infrastructure socket integration', () => {
                 await server.close();
             });
 
-            test('should resolve as error when client disconnects without decision', async () => {
+            test('should resolve as no-op when client disconnects without decision', async () => {
                 const socketInfo = useTestSocket('ipc-decision-timeout');
                 const server = new PlandersonSocketServer(socketInfo.path);
                 await server.start('test plan');
@@ -238,10 +238,7 @@ describe('infrastructure socket integration', () => {
                 client.destroy();
 
                 const decision = await decisionPromise;
-                expect(decision.type).toBe('error');
-                if (decision.type === 'error') {
-                    expect(decision.error).toContain('disconnected');
-                }
+                expect(decision.type).toBe('no-op');
 
                 await server.close();
             });


### PR DESCRIPTION
## Summary

- TUI exits without a decision (Escape, `:q`, Ctrl+C, signal, crash) → hook now exits with code 0 and no JSON output, which Claude Code interprets as allow
- Adds `no-op` to the `SocketMessage` union; any socket disconnect without a prior decision resolves as no-op instead of error
- Removes explicit `deny` send from signal handler in `App.tsx` — disconnect naturally triggers no-op

## Test plan

- [ ] `bun test app/tests/integration/infrastructure/socket.integration.test.ts` — disconnect resolves as `no-op`
- [ ] `bun test app/tests/integration/claude-hook/hook-socket-errors.integration.test.ts` — all three disconnect scenarios return allow (empty stdout)
- [ ] `bun test` — full suite (1557 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)