### PR TITLE
fix(ui): replace endLine backward-subtract with forward scan to fix viewport cutoff

### DIFF
--- a/app/src/components/PlanView/PlanView.tsx
+++ b/app/src/components/PlanView/PlanView.tsx
@@ -81,31 +81,26 @@ export const PlanView: React.FC<PlanViewProps> = ({ sessionId, content, onShowHe
             [state.questions, terminalWidth, paddingX],
         );
 
-        // Calculate visible lines accounting for feedback items
-        // Feedback items (comments/questions) render as extra lines above content lines
-        // We need to reduce the number of content lines shown to fit within viewportHeight
+        // Calculate visible lines accounting for feedback items and line wrapping.
+        // Forward scan: add lines one at a time until adding the next would exceed viewportHeight.
+        // This avoids a unit mismatch where excess (terminal rows) was subtracted from endLine
+        // (a logical line index), causing massive overcorrection on wrapped content.
         const startLine = state.scrollOffset;
-        let endLine = Math.min(state.scrollOffset + viewportHeight, wrappedLines.length);
-
-        // Iteratively adjust endLine to account for feedback lines
-        // We may need multiple iterations if reducing endLine reveals new feedback
-        let prevEndLine = -1;
-        while (endLine !== prevEndLine) {
-            // Count feedback lines using pre-wrapped feedback (avoids re-wrapping)
-            const feedbackCount = countFeedbackLines(startLine, endLine, wrappedComments, wrappedQuestions);
-            // Count terminal lines (accounts for wrapping) instead of logical lines
-            const terminalLinesForContent = countTerminalLinesInRange(wrappedLines, startLine, endLine - 1);
+        let endLine = startLine;
+        while (endLine < wrappedLines.length) {
+            const feedbackCount = countFeedbackLines(startLine, endLine + 1, wrappedComments, wrappedQuestions);
+            const terminalLinesForContent = countTerminalLinesInRange(wrappedLines, startLine, endLine);
             const totalLinesNeeded = terminalLinesForContent + feedbackCount;
 
             if (totalLinesNeeded > viewportHeight) {
-                // Too many lines, reduce content lines
-                const excess = totalLinesNeeded - viewportHeight;
-                prevEndLine = endLine;
-                endLine = Math.max(startLine + 1, endLine - excess);
-            } else {
-                // Fits within viewport
                 break;
             }
+            endLine++;
+        }
+
+        // Always show at least 1 line even if it overflows viewport height
+        if (endLine === startLine) {
+            endLine = startLine + 1;
         }
 
         const visibleLines = wrappedLines.slice(startLine, endLine);

--- a/app/tests/integration/ui/navigation/page-scrolling.integration.test.tsx
+++ b/app/tests/integration/ui/navigation/page-scrolling.integration.test.tsx
@@ -539,4 +539,40 @@ describe('navigation page-scrolling integration', () => {
         // With the fix, Content Line 2 must still be visible after 20 presses
         await waitFor(() => expect(lastFrame()!).toMatch(/Content Line 2\n/));
     });
+
+    /**
+     * Scenario 18: Initial Load With Wrapped Lines Fills Viewport
+     * REQUIREMENT: When a plan opens with a long wrapped line at the top, short lines
+     * that follow it should be visible — viewport must be filled, not just show 1 line.
+     *
+     * Regression test for the endLine overcorrection bug: the old backward-subtract
+     * set endLine = 1 when a long wrapped line consumed many terminal rows, hiding
+     * all subsequent lines even though they easily fit in the remaining space.
+     */
+    test('initial load with wrapped lines fills viewport correctly (regression for endLine overcorrection)', async () => {
+        // 5 short lines (1 row each) followed by 15 long lines (3 rows each at 78-col effective width).
+        // Total logical lines = 20, total terminal rows = 5 + 45 = 50 >> viewportHeight(20).
+        //
+        // Bug (backward-subtract): initial endLine=20, excess=50-20=30, endLine=max(1,20-30)=1
+        //   → only 'Short 1' visible; 'Short 2'-'Short 5' cut off even though they fit.
+        // Fix (forward scan): endLine advances to 10 (5 short + 5 long = 20 rows = viewport)
+        //   → 'Short 1'-'Short 5' all visible.
+        const shortLines = Array.from({ length: 5 }, (_, i) => `Short ${i + 1}`);
+        const longLines = Array.from({ length: 15 }, () => 'W'.repeat(200));
+        const content = [...shortLines, ...longLines].join('\n');
+        const file = useTempPlanFile(content, 'scrolling-wrapped-fills-viewport.md');
+
+        const { lastFrame } = render(<App {...DEFAULT_APP_PROPS} filepath={file} />);
+
+        // Wait for initial render — first short line is present
+        await waitFor(() => expect(lastFrame()!).toContain('Short 1'));
+
+        // All 5 short lines must be visible on initial load.
+        // They each take 1 terminal row; 5 rows easily fit alongside the first 5 long lines.
+        // Bug: endLine overcorrection sets endLine=1, hiding Short 2-5.
+        expect(lastFrame()!).toContain('Short 2');
+        expect(lastFrame()!).toContain('Short 3');
+        expect(lastFrame()!).toContain('Short 4');
+        expect(lastFrame()!).toContain('Short 5');
+    });
 });


### PR DESCRIPTION
## Summary

- Fixes #14: plan viewport showed only 1–2 lines when content had long wrapped lines, leaving most of the terminal blank
- Root cause: `endLine -= excess` in `PlanView.tsx` had a unit mismatch — `excess` was measured in terminal rows but was subtracted from `endLine`, a logical line index. When lines wrap, one logical line spans many terminal rows, so the subtraction massively overshot.
- Fix: replace the backward-subtract loop with a forward scan (add lines one at a time until the next would exceed `viewportHeight`), matching the pattern already used correctly in `calculateMaxScroll`
- Adds regression test (Scenario 18): 5 short lines + 15 wrapped lines at initial load, verifies all short lines are visible

## Test plan

- [x] New regression test added and confirmed to fail before fix, pass after
- [x] All 295 integration tests pass
- [x] All 1241 unit/snapshot tests pass
- [x] Type check and lint clean
- [x] Visual verification with render-tui shows viewport fills correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)