### PR TITLE
fix(ui): strip trailing newline to prevent ghost empty line navigation

### DIFF
--- a/app/src/contexts/PlanViewProvider.test.tsx
+++ b/app/src/contexts/PlanViewProvider.test.tsx
@@ -69,9 +69,10 @@ describe('PlanViewProvider', () => {
 
             const { result } = renderHook(() => usePlanViewStaticContext(), { wrapper });
 
-            // String.split('\n') on "A\nB\nC\n" produces ['A', 'B', 'C', '']
-            expect(result.current.contentLines).toEqual(['A', 'B', 'C', '']);
-            expect(result.current.contentLines.length).toBe(4);
+            // Trailing \n is stripped before splitting so files ending with a newline
+            // (standard for editor-created files) don't produce a ghost empty line.
+            expect(result.current.contentLines).toEqual(['A', 'B', 'C']);
+            expect(result.current.contentLines.length).toBe(3);
         });
 
         test('provides wrappedLines from markdown parsing and line wrapping', () => {

--- a/app/src/contexts/PlanViewProvider.tsx
+++ b/app/src/contexts/PlanViewProvider.tsx
@@ -90,9 +90,12 @@ export const PlanViewProvider: React.FC<PlanViewProviderProps> = ({
     // Memoize static context - recalculates when content or terminal width changes
     const staticValue: PlanViewStaticContextValue = React.useMemo(() => {
         const paddingX = 1;
-        const contentLines = content.split('\n');
+        // Strip a single trailing newline so files ending with \n (standard for editors)
+        // don't produce a ghost empty line that the cursor can navigate to.
+        const normalizedContent = content.replace(/\n$/, '');
+        const contentLines = normalizedContent.split('\n');
         // Parse entire document as markdown (supports code blocks)
-        const lineFormattings = parseMarkdownDocument(content);
+        const lineFormattings = parseMarkdownDocument(normalizedContent);
         // Wrap with markdown formatting
         const wrappedLines = wrapContentWithFormatting(lineFormattings, terminalWidth, paddingX);
         return {

--- a/app/tests/integration/ui/navigation/page-scrolling.integration.test.tsx
+++ b/app/tests/integration/ui/navigation/page-scrolling.integration.test.tsx
@@ -20,6 +20,7 @@ import { App } from '~/App';
 import { useTempPlanFile } from '~/test-utils/fixtures';
 import { Keys, typeKey, typeKeys, typeText, waitFor } from '~/test-utils/ink-helpers';
 import { DEFAULT_APP_PROPS } from '~/test-utils/integration-defaults';
+import { getCursorLine, hasCursorHighlight } from '~/test-utils/visual-assertions';
 
 describe('navigation page-scrolling integration', () => {
     afterEach(() => {
@@ -512,6 +513,37 @@ describe('navigation page-scrolling integration', () => {
         expect(afterFinalScroll).not.toMatch(/^\s*Line 2\s*$/m);
         // Verify cursor moved to line 20 (Line 21 in display)
         expect(afterFinalScroll).toContain('Line 21');
+    });
+
+    /**
+     * Scenario 18: Single-Line Document - DOWN Arrow Cursor Boundary
+     * BUG: DOWN_ARROW in a single-line document moves cursor to a ghost trailing empty line.
+     * REQUIREMENT: Cursor must stay on the only content line; DOWN is a no-op at document end.
+     *
+     * Confirmed via render-tui: after DOWN_ARROW the content line loses cursor highlight and
+     * a highlighted blank space appears below it (the ghost trailing line from the document parser).
+     */
+    test('cursor stays on content line when pressing DOWN in single-line document', async () => {
+        // File ends with \n — standard for any editor-created file.
+        // Without the fix, content.split('\n') yields ['This is the only line', ''],
+        // so contentLines.length === 2 and DOWN_ARROW moves cursor to the ghost empty line.
+        const lineText = 'This is the only line';
+        const file = useTempPlanFile(`${lineText}\n`, 'single-line-down.md');
+        const { stdin, lastFrame } = render(<App {...DEFAULT_APP_PROPS} filepath={file} />);
+
+        await waitFor(() => expect(hasCursorHighlight(lastFrame()!, lineText)).toBe(true));
+
+        // Press DOWN — should be a no-op at the end of a single-line document
+        await typeKey(stdin, Keys.DOWN_ARROW);
+
+        await waitFor(() => {
+            const frame = lastFrame()!;
+            // EXPECTED: cursor remains on the content line
+            // BUG: cursor moves to ghost trailing empty line; content line loses highlight
+            expect(hasCursorHighlight(frame, lineText)).toBe(true);
+            // The cursor line text should be the content, not an empty string
+            expect(getCursorLine(frame)).toBe(lineText);
+        });
     });
 
     /**


### PR DESCRIPTION
## Summary

- Files ending with `\n` (standard for all editor-created files) caused `content.split('\n')` to produce an empty trailing element, making it a navigable logical line
- DOWN on the last real content line moved the cursor to this ghost empty line, which rendered as a highlighted blank space — cursor appeared to vanish
- Fix normalizes content in `PlanViewProvider` before computing `contentLines` and `lineFormattings`, preserving the `contentLines.length === wrappedLines.length` invariant

Closes #16

## Test plan

- [ ] New integration test: `cursor stays on content line when pressing DOWN in single-line document` — was failing before fix, passes after
- [ ] Full integration suite: 296 pass, 0 fail
- [ ] Verified with render-tui: after DOWN in a single-line file, cursor highlight stays on the content line (previously moved to ghost blank line below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)