### PR TITLE
chore(deps): add workflow to update bun.lock for dependabot prs

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,37 @@
+name: Update bun.lock for Dependabot
+
+on:
+    pull_request:
+        branches: [main]
+
+permissions:
+    contents: write
+
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+    update-lockfile:
+        name: Update bun.lock
+        if: github.actor == 'dependabot[bot]'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+              with:
+                  ref: ${{ github.head_ref }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: 1.3.7
+
+            - name: Regenerate lockfile
+              run: bun install
+
+            - name: Commit updated bun.lock
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add bun.lock
+                  git diff --staged --quiet || git commit -m "chore: update bun.lock"
+                  git push


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers on Dependabot PRs and regenerates `bun.lock`
- Fixes CI failures caused by Dependabot updating `package.json` without updating the Bun lockfile

## Test plan
- [ ] Merge this PR
- [ ] Comment `@dependabot recreate` on PR #20 to trigger a fresh Dependabot PR
- [ ] Verify the new PR includes an updated `bun.lock` and CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)