### PR TITLE
fix(deps): use bot pat to trigger ci after lockfile update

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -19,7 +19,7 @@ jobs:
             - uses: actions/checkout@v5
               with:
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.BOT_PAT }}
 
             - uses: oven-sh/setup-bun@v2
               with:


### PR DESCRIPTION
## Summary
- Replaces `GITHUB_TOKEN` with `BOT_PAT` in the Dependabot lockfile workflow
- Commits pushed with `GITHUB_TOKEN` don't trigger other workflows (GitHub security limitation), so CI never ran after the lockfile was committed

## Test plan
- [ ] Merge this PR
- [ ] Comment `@dependabot recreate` on the Dependabot PR
- [ ] Verify the new lockfile commit triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)