### PR TITLE
feat(ui): add home/end key support in input navigation

### DIFF
--- a/app/src/utils/input/navigation.test.ts
+++ b/app/src/utils/input/navigation.test.ts
@@ -184,6 +184,24 @@ describe('input navigation', () => {
             expect(getLastAction()).toEqual({ type: 'MOVE_INPUT_CURSOR_TO_END' });
         });
 
+        test('returns true and dispatches MOVE_INPUT_CURSOR_TO_START for Home', () => {
+            const { dispatch, getLastAction } = createMockDispatch();
+
+            const result = handleInputNavigation('', createKey({ home: true }), dispatch, 80, 30);
+
+            expect(result).toBe(true);
+            expect(getLastAction()).toEqual({ type: 'MOVE_INPUT_CURSOR_TO_START' });
+        });
+
+        test('returns true and dispatches MOVE_INPUT_CURSOR_TO_END for End', () => {
+            const { dispatch, getLastAction } = createMockDispatch();
+
+            const result = handleInputNavigation('', createKey({ end: true }), dispatch, 80, 30);
+
+            expect(result).toBe(true);
+            expect(getLastAction()).toEqual({ type: 'MOVE_INPUT_CURSOR_TO_END' });
+        });
+
         test('returns false for regular "a" without ctrl', () => {
             const { dispatch, getLastAction } = createMockDispatch();
 

--- a/app/src/utils/input/navigation.ts
+++ b/app/src/utils/input/navigation.ts
@@ -73,15 +73,12 @@ export const handleInputNavigation = (
     }
 
     // Line navigation
-    // Note: HOME/END keys are not supported because Ink's useInput Key type
-    // doesn't expose key.home or key.end properties (TypeScript compilation error).
-    // Ctrl+A and Ctrl+E serve as the standard terminal alternatives.
-    if (input === 'a' && key.ctrl) {
+    if (key.home || (input === 'a' && key.ctrl)) {
         dispatch({ type: 'MOVE_INPUT_CURSOR_TO_START' });
         return true;
     }
 
-    if (input === 'e' && key.ctrl) {
+    if (key.end || (input === 'e' && key.ctrl)) {
         dispatch({ type: 'MOVE_INPUT_CURSOR_TO_END' });
         return true;
     }


### PR DESCRIPTION
## Summary

- Ink 6 (added in #20) exposes `key.home` and `key.end` in its `Key` type
- Wire `Home` → `MOVE_INPUT_CURSOR_TO_START` (same as Ctrl+A) and `End` → `MOVE_INPUT_CURSOR_TO_END` (same as Ctrl+E) in `handleInputNavigation`
- Removes the stale comment explaining why these keys were previously unsupported

## Test plan

- [x] Added unit tests for `key.home` and `key.end` in `navigation.test.ts`
- [x] All 1243 unit tests + 296 integration tests pass locally
- [x] Format, lint, type-check, and build all clean

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)