### PR TITLE
fix(test): reduce stdin timeout in hook integration tests to prevent flakiness

### DIFF
--- a/app/src/commands/hook.ts
+++ b/app/src/commands/hook.ts
@@ -23,7 +23,10 @@ const DEFAULT_TIMEOUT_SECONDS =
         ? Number.parseInt(process.env.PLANDERSON_TIMEOUT_SECONDS, 10)
         : 900;
 const MAX_STDIN_BYTES = 10 * 1024 * 1024; // 10MB limit
-const STDIN_TIMEOUT_MS = 5000; // 5 second timeout for reading stdin
+const STDIN_TIMEOUT_MS =
+    process.env.PLANDERSON_STDIN_TIMEOUT_MS !== undefined && process.env.PLANDERSON_STDIN_TIMEOUT_MS !== ''
+        ? Number.parseInt(process.env.PLANDERSON_STDIN_TIMEOUT_MS, 10)
+        : 5000;
 const MAX_SOCKET_PATH_LENGTH = 104; // macOS/BSD limit for Unix domain sockets
 
 // Zod schemas for runtime validation

--- a/app/tests/integration/claude-hook/helpers.ts
+++ b/app/tests/integration/claude-hook/helpers.ts
@@ -21,7 +21,10 @@ export const HOOK_PATH = path.join(__dirname, '../../../src/commands/hook.ts');
  * The temp HOME directory is auto-cleaned after each test.
  *
  * Defaults: TMUX and TMUX_PANE are cleared to prevent tmux auto-launch.
- * Override via extraEnv to test tmux-specific behavior.
+ * PLANDERSON_STDIN_TIMEOUT_MS is set to 1000ms so that if the stdin 'end' event
+ * is missed in CI (a bun subprocess timing edge case), the hook falls back quickly
+ * rather than waiting the full 5s, preventing test timeouts.
+ * Override via extraEnv to test specific behavior.
  */
 export const spawnHook = (extraEnv: Record<string, string | undefined> = {}, baseDir?: string): HookProcess => {
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'planderson-test-home-'));
@@ -43,6 +46,7 @@ export const spawnHook = (extraEnv: Record<string, string | undefined> = {}, bas
             HOME: fakeHome,
             TMUX: undefined,
             TMUX_PANE: undefined,
+            PLANDERSON_STDIN_TIMEOUT_MS: '1000',
             ...extraEnv,
         },
     }) as HookProcess;


### PR DESCRIPTION
## Summary

* Two integration tests were flaky in CI: `missing required field tool_name` and `hook encounters exception -> logs error to error.log` — both timed out at exactly 10s
* Root cause: when the stdin `'end'` event is missed in a bun subprocess (a CI timing edge case), `readStdinSafely` falls back to its hardcoded 5s timeout. combined with bun startup overhead in CI (~2-3s), the hook doesn't exit until ~7-8s — tight enough to occasionally exceed the 10s test timeout
* The same risk applies to all hook tests that write stdin without a socket path, including tests in `hook-validation.integration.test.ts` with only 5s timeouts

**Fix**: add `PLANDERSON_STDIN_TIMEOUT_MS` env var (same pattern as `PLANDERSON_TIMEOUT_SECONDS`) and default it to `1000ms` in `spawnHook`. in the normal path stdin closes in <100ms so the 1s fallback is never hit. worst case in CI: 1s + startup, well within all test timeouts.

**Validated**: 50/50 passes across 10 parallel agents each running 5 consecutive runs locally.

## Test plan

* CI integration tests pass cleanly
* `no stdin input -> hook times out` still passes (just completes in ~1s instead of ~5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)