### PR TITLE
feat(hook): restructure question deny message with xml and improved instructions

### DIFF
--- a/app/src/hooks/useConfirmKeys.test.tsx
+++ b/app/src/hooks/useConfirmKeys.test.tsx
@@ -449,7 +449,7 @@ describe('useConfirmKeys', () => {
                 // Simulate pressing Enter
                 act(() => {
                     const message =
-                        '<response_instructions>\nRespond with plain text only — this response must not call ExitPlanMode or any other tool.\nThe reason: the user needs to read your answers and may ask follow-up questions before deciding to proceed.\nOnly call ExitPlanMode after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead").\n</response_instructions>\n\n<questions>\n  <question>\n    <ref line="4">Line 4</ref>\n    <feedback>Why this approach?</feedback>\n  </question>\n</questions>';
+                        '<response_instructions>\nRespond with plain text only — this response must not call ExitPlanMode or any other tool.\nThe reason: the questions below are for discussion — the user will read your answers and may ask follow-up questions before deciding whether to proceed with the plan.\nOnly update the plan after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead").\n</response_instructions>\n\n<questions>\n  <question>\n    <ref line="4">Line 4</ref>\n    <feedback>Why this approach?</feedback>\n  </question>\n</questions>';
                     result.current.onDeny(message, message);
                 });
 
@@ -515,7 +515,7 @@ describe('useConfirmKeys', () => {
                 // Simulate pressing Enter
                 act(() => {
                     const message =
-                        '<response_instructions>\nRespond with plain text only — this response must not call ExitPlanMode or any other tool.\nThe reason: the user needs to read your answers and may ask follow-up questions before deciding to proceed.\nDo not act on the comments or deletions below — hold them until the user confirms to proceed.\nOnly call ExitPlanMode after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead") — and when you do, apply all the feedback below.\n</response_instructions>\n\n<questions>\n  <question>\n    <ref line="6">Line 6</ref>\n    <feedback>Question text</feedback>\n  </question>\n</questions>\n\n<comments>\n  <comment>\n    <ref line="3">Line 3</ref>\n    <feedback>Comment text</feedback>\n  </comment>\n</comments>\n\n<deletions>\n  <deletion>\n    <ref line="11">Line 11</ref>\n  </deletion>\n</deletions>';
+                        '<response_instructions>\nRespond with plain text only — this response must not call ExitPlanMode or any other tool.\nThe reason: the questions below are for discussion — the user will read your answers and may ask follow-up questions before deciding whether to proceed with the plan. The comments and deletions are plan modifications that will be applied when you return to plan mode.\nDo not act on the comments or deletions below — hold them until the user confirms to proceed.\nOnly update the plan after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead") — and when you do, apply all the feedback below.\n</response_instructions>\n\n<questions>\n  <question>\n    <ref line="6">Line 6</ref>\n    <feedback>Question text</feedback>\n  </question>\n</questions>\n\n<comments>\n  <comment>\n    <ref line="3">Line 3</ref>\n    <feedback>Comment text</feedback>\n  </comment>\n</comments>\n\n<deletions>\n  <deletion>\n    <ref line="11">Line 11</ref>\n  </deletion>\n</deletions>';
                     result.current.onDeny(message, message);
                 });
 

--- a/app/src/hooks/useConfirmKeys.test.tsx
+++ b/app/src/hooks/useConfirmKeys.test.tsx
@@ -449,14 +449,14 @@ describe('useConfirmKeys', () => {
                 // Simulate pressing Enter
                 act(() => {
                     const message =
-                        'Questions about the plan:\nLine 4: "Line 4"\nWhy this approach?\n\nPlease answer these questions. Do not create a new plan yet. After discussion, we will return to plan mode. Still use the below feedback when we return to plan mode.';
+                        '<response_instructions>\nRespond with plain text only — this response must not call ExitPlanMode or any other tool.\nThe reason: the user needs to read your answers and may ask follow-up questions before deciding to proceed.\nOnly call ExitPlanMode after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead").\n</response_instructions>\n\n<questions>\n  <question>\n    <ref line="4">Line 4</ref>\n    <feedback>Why this approach?</feedback>\n  </question>\n</questions>';
                     result.current.onDeny(message, message);
                 });
 
                 expect(result.current.onDeny).toHaveBeenCalled();
                 const callArgs = (result.current.onDeny as any).mock.calls[0];
-                expect(callArgs[0]).toContain('Questions about the plan:');
-                expect(callArgs[0]).toContain('Line 4:');
+                expect(callArgs[0]).toContain('<questions>');
+                expect(callArgs[0]).toContain('<ref line="4">');
                 expect(callArgs[0]).toContain('Why this approach?');
             });
 
@@ -480,15 +480,16 @@ describe('useConfirmKeys', () => {
 
                 // Simulate pressing Enter
                 act(() => {
-                    const message = 'Delete lines:\nLine 8: "Line 8"\nLine 9: "Line 9"';
+                    const message =
+                        '<deletions>\n  <deletion>\n    <ref line="8">Line 8</ref>\n  </deletion>\n  <deletion>\n    <ref line="9">Line 9</ref>\n  </deletion>\n</deletions>';
                     result.current.onDeny(message, message);
                 });
 
                 expect(result.current.onDeny).toHaveBeenCalled();
                 const callArgs = (result.current.onDeny as any).mock.calls[0];
-                expect(callArgs[0]).toContain('Delete lines:');
-                expect(callArgs[0]).toContain('Line 8:');
-                expect(callArgs[0]).toContain('Line 9:');
+                expect(callArgs[0]).toContain('<deletions>');
+                expect(callArgs[0]).toContain('<ref line="8">');
+                expect(callArgs[0]).toContain('<ref line="9">');
             });
 
             test('calls onDeny with formatted feedback message (mixed feedback types)', () => {
@@ -514,15 +515,15 @@ describe('useConfirmKeys', () => {
                 // Simulate pressing Enter
                 act(() => {
                     const message =
-                        'Questions about the plan:\nLine 6: "Line 6"\nQuestion text\n\nPlease answer these questions. Do not create a new plan yet. After discussion, we will return to plan mode. Still use the below feedback when we return to plan mode.\n\nComments on the plan:\nLine 3: "Line 3"\nComment text\n\nDelete lines:\nLine 11: "Line 11"';
+                        '<response_instructions>\nRespond with plain text only — this response must not call ExitPlanMode or any other tool.\nThe reason: the user needs to read your answers and may ask follow-up questions before deciding to proceed.\nDo not act on the comments or deletions below — hold them until the user confirms to proceed.\nOnly call ExitPlanMode after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead") — and when you do, apply all the feedback below.\n</response_instructions>\n\n<questions>\n  <question>\n    <ref line="6">Line 6</ref>\n    <feedback>Question text</feedback>\n  </question>\n</questions>\n\n<comments>\n  <comment>\n    <ref line="3">Line 3</ref>\n    <feedback>Comment text</feedback>\n  </comment>\n</comments>\n\n<deletions>\n  <deletion>\n    <ref line="11">Line 11</ref>\n  </deletion>\n</deletions>';
                     result.current.onDeny(message, message);
                 });
 
                 expect(result.current.onDeny).toHaveBeenCalled();
                 const callArgs = (result.current.onDeny as any).mock.calls[0];
-                expect(callArgs[0]).toContain('Questions about the plan:');
-                expect(callArgs[0]).toContain('Comments on the plan:');
-                expect(callArgs[0]).toContain('Delete lines:');
+                expect(callArgs[0]).toContain('<questions>');
+                expect(callArgs[0]).toContain('<comments>');
+                expect(callArgs[0]).toContain('<deletions>');
             });
 
             test('includes original line content in formatted message', () => {

--- a/app/src/utils/feedback/decision.test.ts
+++ b/app/src/utils/feedback/decision.test.ts
@@ -77,12 +77,12 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Comments on the plan:');
-                expect(result).toContain('Line 1: "line 1"');
-                expect(result).toContain('This needs improvement');
-                expect(result).toContain('Line 3: "line 3"');
-                expect(result).toContain('Consider refactoring');
-                expect(result).not.toContain('Delete lines:');
+                expect(result).toContain('<comments>');
+                expect(result).toContain('<ref line="1">line 1</ref>');
+                expect(result).toContain('<feedback>This needs improvement</feedback>');
+                expect(result).toContain('<ref line="3">line 3</ref>');
+                expect(result).toContain('<feedback>Consider refactoring</feedback>');
+                expect(result).not.toContain('<deletions>');
             });
 
             test('formats deletions only', () => {
@@ -97,10 +97,10 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Delete lines:');
-                expect(result).toContain('Line 2: "line 2"');
-                expect(result).toContain('Line 4: "line 4"');
-                expect(result).not.toContain('Comments on the plan:');
+                expect(result).toContain('<deletions>');
+                expect(result).toContain('<ref line="2">line 2</ref>');
+                expect(result).toContain('<ref line="4">line 4</ref>');
+                expect(result).not.toContain('<comments>');
             });
 
             test('formats both comments and deletions with blank line separator', () => {
@@ -115,11 +115,11 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Comments on the plan:');
-                expect(result).toContain('Line 1: "line 1"');
-                expect(result).toContain('Fix this');
-                expect(result).toContain('Delete lines:');
-                expect(result).toContain('Line 3: "line 3"');
+                expect(result).toContain('<comments>');
+                expect(result).toContain('<ref line="1">line 1</ref>');
+                expect(result).toContain('<feedback>Fix this</feedback>');
+                expect(result).toContain('<deletions>');
+                expect(result).toContain('<ref line="3">line 3</ref>');
                 expect(result).toContain('\n\n');
             });
 
@@ -140,23 +140,23 @@ describe('feedback decision', () => {
                 )!;
 
                 // Verify comments appear in ascending order
-                const commentSection = result.split('Delete lines:')[0];
-                const line2Index = commentSection.indexOf('Line 2:');
-                const line4Index = commentSection.indexOf('Line 4:');
-                const line6Index = commentSection.indexOf('Line 6:');
+                const commentSection = result.split('<deletions>')[0];
+                const line2Index = commentSection.indexOf('<ref line="2">');
+                const line4Index = commentSection.indexOf('<ref line="4">');
+                const line6Index = commentSection.indexOf('<ref line="6">');
                 expect(line2Index).toBeLessThan(line4Index);
                 expect(line4Index).toBeLessThan(line6Index);
 
                 // Verify deletions appear in ascending order
-                const deleteSection = result.split('Delete lines:')[1];
-                const del3Index = deleteSection.indexOf('Line 3:');
-                const del5Index = deleteSection.indexOf('Line 5:');
-                const del8Index = deleteSection.indexOf('Line 8:');
+                const deleteSection = result.split('<deletions>')[1];
+                const del3Index = deleteSection.indexOf('<ref line="3">');
+                const del5Index = deleteSection.indexOf('<ref line="5">');
+                const del8Index = deleteSection.indexOf('<ref line="8">');
                 expect(del3Index).toBeLessThan(del5Index);
                 expect(del5Index).toBeLessThan(del8Index);
             });
 
-            test('includes original line content in quotes', () => {
+            test('includes original line content in element body', () => {
                 const comments = new Map<number, FeedbackEntry>([[0, { text: 'Comment here', lines: [0] }]]);
                 const deletedLines = new Set<number>([1]);
                 const contentLines = ['const foo = "bar"', 'let x = 42'];
@@ -168,13 +168,13 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Line 1: "const foo = "bar""');
-                expect(result).toContain('Line 2: "let x = 42"');
+                expect(result).toContain('<ref line="1">const foo = "bar"</ref>');
+                expect(result).toContain('<ref line="2">let x = 42</ref>');
             });
         });
 
         describe('multi-line comments', () => {
-            test('formats multi-line comment with range using stored lines array', () => {
+            test('formats multi-line comment with individual ref per line', () => {
                 const comments = new Map([[0, { text: 'Fix this', lines: [0, 1, 2] }]]);
                 const contentLines = ['line 1', 'line 2', 'line 3', 'line 4'];
 
@@ -185,12 +185,13 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Lines 1-3:');
-                expect(result).toContain('"line 1" "line 2" "line 3"');
-                expect(result).toContain('Fix this');
+                expect(result).toContain('<ref line="1">line 1</ref>');
+                expect(result).toContain('<ref line="2">line 2</ref>');
+                expect(result).toContain('<ref line="3">line 3</ref>');
+                expect(result).toContain('<feedback>Fix this</feedback>');
             });
 
-            test('formats non-consecutive range correctly', () => {
+            test('formats non-consecutive lines with individual ref per line', () => {
                 const comments = new Map([[0, { text: 'Non-consecutive', lines: [0, 2, 4] }]]);
                 const contentLines = ['line 1', 'line 2', 'line 3', 'line 4', 'line 5'];
 
@@ -201,9 +202,10 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Lines 1-5:');
-                expect(result).toContain('"line 1" "line 3" "line 5"');
-                expect(result).toContain('Non-consecutive');
+                expect(result).toContain('<ref line="1">line 1</ref>');
+                expect(result).toContain('<ref line="3">line 3</ref>');
+                expect(result).toContain('<ref line="5">line 5</ref>');
+                expect(result).toContain('<feedback>Non-consecutive</feedback>');
             });
 
             test('handles mix of single and multi-line comments', () => {
@@ -221,9 +223,10 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Line 1: "l0"');
-                expect(result).toContain('Lines 3-4: "l2" "l3"');
-                expect(result).toContain('Line 6: "l5"');
+                expect(result).toContain('<ref line="1">l0</ref>');
+                expect(result).toContain('<ref line="3">l2</ref>');
+                expect(result).toContain('<ref line="4">l3</ref>');
+                expect(result).toContain('<ref line="6">l5</ref>');
             });
         });
 
@@ -239,16 +242,14 @@ describe('feedback decision', () => {
 
                 const result = formatFeedbackMessage(comments, questions, deletedLines, contentLines);
 
-                expect(result).toContain('Questions about the plan:');
-                expect(result).toContain('Line 1: "line 1"');
-                expect(result).toContain('Why this approach?');
-                expect(result).toContain('Line 3: "line 3"');
-                expect(result).toContain('Is this needed?');
-                expect(result).toContain('Do NOT call ExitPlanMode in this response');
-                expect(result).toContain(
-                    'Only call ExitPlanMode again after the user has explicitly asked you to proceed',
-                );
-                expect(result).not.toContain('Comments on the plan:');
+                expect(result).toContain('<questions>');
+                expect(result).toContain('<ref line="1">line 1</ref>');
+                expect(result).toContain('<feedback>Why this approach?</feedback>');
+                expect(result).toContain('<ref line="3">line 3</ref>');
+                expect(result).toContain('<feedback>Is this needed?</feedback>');
+                expect(result).toContain('must not call ExitPlanMode');
+                expect(result).toContain('explicitly tells you to continue');
+                expect(result).not.toContain('<comments>');
             });
 
             test('formats questions before comments', () => {
@@ -259,11 +260,9 @@ describe('feedback decision', () => {
 
                 const result = formatFeedbackMessage(comments, questions, deletedLines, contentLines);
 
-                // Questions section should appear before comments section
-                const questionsIndex = result!.indexOf('Questions about the plan:');
-                const commentsIndex = result!.indexOf('Comments on the plan:');
+                const questionsIndex = result!.indexOf('<questions>');
+                const commentsIndex = result!.indexOf('<comments>');
                 expect(questionsIndex).toBeLessThan(commentsIndex);
-                expect(result).toContain('still use the below feedback');
             });
 
             test('includes explicit instructions with questions', () => {
@@ -274,11 +273,63 @@ describe('feedback decision', () => {
 
                 const result = formatFeedbackMessage(comments, questions, deletedLines, contentLines);
 
-                expect(result).toContain('Do NOT call ExitPlanMode in this response');
-                expect(result).toContain(
-                    'Only call ExitPlanMode again after the user has explicitly asked you to proceed',
+                expect(result).toContain('<response_instructions>');
+                expect(result).toContain('must not call ExitPlanMode');
+                expect(result).toContain('explicitly tells you to continue');
+            });
+
+            test('omits hold instruction when questions are present without comments or deletions', () => {
+                const questions = new Map<number, FeedbackEntry>([[0, { text: 'Question', lines: [0] }]]);
+                const contentLines = ['line 1'];
+
+                const result = formatFeedbackMessage(
+                    new Map<number, FeedbackEntry>(),
+                    questions,
+                    new Set(),
+                    contentLines,
                 );
-                expect(result).toContain('still use the below feedback');
+
+                expect(result).not.toContain('Do not act on');
+                expect(result).not.toContain('apply all the feedback below');
+            });
+
+            test('includes hold instruction for comments when questions are present', () => {
+                const comments = new Map<number, FeedbackEntry>([[0, { text: 'Fix this', lines: [0] }]]);
+                const questions = new Map<number, FeedbackEntry>([[1, { text: 'Why?', lines: [1] }]]);
+                const contentLines = ['line 1', 'line 2'];
+
+                const result = formatFeedbackMessage(comments, questions, new Set(), contentLines);
+
+                expect(result).toContain('Do not act on the comments below');
+                expect(result).toContain('apply all the feedback below');
+                expect(result).not.toContain('Do not act on the deletions below');
+            });
+
+            test('includes hold instruction for deletions when questions are present', () => {
+                const questions = new Map<number, FeedbackEntry>([[0, { text: 'Why?', lines: [0] }]]);
+                const contentLines = ['line 1', 'line 2'];
+
+                const result = formatFeedbackMessage(
+                    new Map<number, FeedbackEntry>(),
+                    questions,
+                    new Set([1]),
+                    contentLines,
+                );
+
+                expect(result).toContain('Do not act on the deletions below');
+                expect(result).toContain('apply all the feedback below');
+                expect(result).not.toContain('Do not act on the comments below');
+            });
+
+            test('includes hold instruction for comments or deletions when all three are present', () => {
+                const comments = new Map<number, FeedbackEntry>([[0, { text: 'Fix this', lines: [0] }]]);
+                const questions = new Map<number, FeedbackEntry>([[1, { text: 'Why?', lines: [1] }]]);
+                const contentLines = ['line 1', 'line 2', 'line 3'];
+
+                const result = formatFeedbackMessage(comments, questions, new Set([2]), contentLines);
+
+                expect(result).toContain('Do not act on the comments or deletions below');
+                expect(result).toContain('apply all the feedback below');
             });
         });
 
@@ -295,8 +346,8 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Comments on the plan:');
-                expect(result).toContain('Line 1: "undefined"');
+                expect(result).toContain('<comments>');
+                expect(result).toContain('<ref line="1">undefined</ref>');
             });
 
             test('handles line indices beyond contentLines bounds', () => {
@@ -311,8 +362,8 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
-                expect(result).toContain('Line 11: "undefined"');
-                expect(result).toContain('Line 21: "undefined"');
+                expect(result).toContain('<ref line="11">undefined</ref>');
+                expect(result).toContain('<ref line="21">undefined</ref>');
             });
         });
     });

--- a/app/src/utils/feedback/decision.test.ts
+++ b/app/src/utils/feedback/decision.test.ts
@@ -248,7 +248,8 @@ describe('feedback decision', () => {
                 expect(result).toContain('<ref line="3">line 3</ref>');
                 expect(result).toContain('<feedback>Is this needed?</feedback>');
                 expect(result).toContain('must not call ExitPlanMode');
-                expect(result).toContain('explicitly tells you to continue');
+                expect(result).toContain('questions below are for discussion');
+                expect(result).toContain('Only update the plan after the user explicitly tells you to continue');
                 expect(result).not.toContain('<comments>');
             });
 
@@ -275,7 +276,7 @@ describe('feedback decision', () => {
 
                 expect(result).toContain('<response_instructions>');
                 expect(result).toContain('must not call ExitPlanMode');
-                expect(result).toContain('explicitly tells you to continue');
+                expect(result).toContain('Only update the plan after the user explicitly tells you to continue');
             });
 
             test('omits hold instruction when questions are present without comments or deletions', () => {
@@ -300,6 +301,7 @@ describe('feedback decision', () => {
 
                 const result = formatFeedbackMessage(comments, questions, new Set(), contentLines);
 
+                expect(result).toContain('comments are plan modifications');
                 expect(result).toContain('Do not act on the comments below');
                 expect(result).toContain('apply all the feedback below');
                 expect(result).not.toContain('Do not act on the deletions below');
@@ -316,6 +318,7 @@ describe('feedback decision', () => {
                     contentLines,
                 );
 
+                expect(result).toContain('deletions are plan modifications');
                 expect(result).toContain('Do not act on the deletions below');
                 expect(result).toContain('apply all the feedback below');
                 expect(result).not.toContain('Do not act on the comments below');
@@ -328,6 +331,7 @@ describe('feedback decision', () => {
 
                 const result = formatFeedbackMessage(comments, questions, new Set([2]), contentLines);
 
+                expect(result).toContain('comments and deletions are plan modifications');
                 expect(result).toContain('Do not act on the comments or deletions below');
                 expect(result).toContain('apply all the feedback below');
             });

--- a/app/src/utils/feedback/decision.ts
+++ b/app/src/utils/feedback/decision.ts
@@ -28,6 +28,13 @@ export const sendDecisionViaSocket = (
     }
 };
 
+// Build XML ref elements for a set of line indices
+const buildRefs = (lines: number[], contentLines: string[]): string =>
+    lines
+        .sort((a, b) => a - b)
+        .map((line) => `    <ref line="${line + 1}">${contentLines[line]}</ref>`)
+        .join('\n');
+
 // Format feedback message for deny action
 export const formatFeedbackMessage = (
     comments: Map<number, FeedbackEntry>,
@@ -40,57 +47,45 @@ export const formatFeedbackMessage = (
     // Questions section FIRST (if present)
     if (questions.size > 0) {
         const questionEntries = [...questions.entries()].sort(([a], [b]) => a - b);
-        const questionBlocks: string[] = [];
-
-        questionEntries.forEach(([anchorLine, entry]) => {
-            const lines = entry.lines.sort((a, b) => a - b); // Ensure sorted
-
-            if (lines.length > 1) {
-                // Multi-line question: show range with all quoted line contents
-                const lineContents = lines.map((line) => `"${contentLines[line]}"`).join(' ');
-                questionBlocks.push(`Lines ${lines[0] + 1}-${lines.at(-1)! + 1}: ${lineContents}\n${entry.text}`);
-            } else {
-                // Single line question: existing format
-                questionBlocks.push(`Line ${anchorLine + 1}: "${contentLines[anchorLine]}"\n${entry.text}`);
-            }
+        const questionItems = questionEntries.map(([, entry]) => {
+            const lines = entry.lines.sort((a, b) => a - b);
+            return `  <question>\n${buildRefs(lines, contentLines)}\n    <feedback>${entry.text}</feedback>\n  </question>`;
         });
 
+        const holdParts: string[] = [];
+        if (comments.size > 0) holdParts.push('comments');
+        if (deletedLines.size > 0) holdParts.push('deletions');
+
+        const holdLine =
+            holdParts.length > 0
+                ? `\nDo not act on the ${holdParts.join(' or ')} below — hold them until the user confirms to proceed.`
+                : '';
+        const applyClause = holdParts.length > 0 ? ` — and when you do, apply all the feedback below` : '';
+
         messageParts.push(
-            `Questions about the plan:\n${questionBlocks.join('\n')}\n\n` +
-                `Please answer these questions. Do NOT call ExitPlanMode in this response — ` +
-                `just answer the questions with plain text and stop. ` +
-                `The user will read your answers and reply in chat. ` +
-                `Only call ExitPlanMode again after the user has explicitly asked you to proceed. ` +
-                `When you return to plan mode, still use the below feedback.`,
+            `<response_instructions>\n` +
+                `Respond with plain text only — this response must not call ExitPlanMode or any other tool.\n` +
+                `The reason: the user needs to read your answers and may ask follow-up questions before deciding to proceed.${holdLine}\n` +
+                `Only call ExitPlanMode after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead")${applyClause}.\n` +
+                `</response_instructions>\n\n` +
+                `<questions>\n${questionItems.join('\n')}\n</questions>`,
         );
     }
 
     if (comments.size > 0) {
         const commentEntries = [...comments.entries()].sort(([a], [b]) => a - b);
-        const commentBlocks: string[] = [];
-
-        commentEntries.forEach(([anchorLine, entry]) => {
-            const lines = entry.lines.sort((a, b) => a - b); // Ensure sorted
-
-            if (lines.length > 1) {
-                // Multi-line comment: show range with all quoted line contents
-                const lineContents = lines.map((line) => `"${contentLines[line]}"`).join(' ');
-                commentBlocks.push(`Lines ${lines[0] + 1}-${lines.at(-1)! + 1}: ${lineContents}\n${entry.text}`);
-            } else {
-                // Single line comment: existing format
-                commentBlocks.push(`Line ${anchorLine + 1}: "${contentLines[anchorLine]}"\n${entry.text}`);
-            }
+        const commentItems = commentEntries.map(([, entry]) => {
+            const lines = entry.lines.sort((a, b) => a - b);
+            return `  <comment>\n${buildRefs(lines, contentLines)}\n    <feedback>${entry.text}</feedback>\n  </comment>`;
         });
-
-        messageParts.push(`Comments on the plan:\n${commentBlocks.join('\n')}`);
+        messageParts.push(`<comments>\n${commentItems.join('\n')}\n</comments>`);
     }
 
     if (deletedLines.size > 0) {
-        const deletedBlocks = [...deletedLines]
+        const deletionItems = [...deletedLines]
             .sort((a, b) => a - b)
-            .map((line) => `Line ${line + 1}: "${contentLines[line]}"`)
-            .join('\n');
-        messageParts.push(`Delete lines:\n${deletedBlocks}`);
+            .map((line) => `  <deletion>\n    <ref line="${line + 1}">${contentLines[line]}</ref>\n  </deletion>`);
+        messageParts.push(`<deletions>\n${deletionItems.join('\n')}\n</deletions>`);
     }
 
     if (messageParts.length > 0) {

--- a/app/src/utils/feedback/decision.ts
+++ b/app/src/utils/feedback/decision.ts
@@ -35,6 +35,39 @@ const buildRefs = (lines: number[], contentLines: string[]): string =>
         .map((line) => `    <ref line="${line + 1}">${contentLines[line]}</ref>`)
         .join('\n');
 
+/**
+ * Formats a deny message from the user's feedback to send back to Claude.
+ *
+ * When questions are present, prepends a `<response_instructions>` block telling
+ * Claude to answer conversationally and wait for the user before updating the plan.
+ * Comments and deletions are included as XML for Claude to apply when it returns
+ * to plan mode.
+ *
+ * @example
+ * ```
+ * <response_instructions>...</response_instructions>
+ *
+ * <questions>
+ *   <question>
+ *     <ref line="2">Step 2: Create the API endpoints</ref>
+ *     <feedback>Why REST and not GraphQL here?</feedback>
+ *   </question>
+ * </questions>
+ *
+ * <comments>
+ *   <comment>
+ *     <ref line="1">Step 1: Set up the database schema</ref>
+ *     <feedback>Use Postgres not SQLite</feedback>
+ *   </comment>
+ * </comments>
+ *
+ * <deletions>
+ *   <deletion>
+ *     <ref line="3">Step 3: Add authentication middleware</ref>
+ *   </deletion>
+ * </deletions>
+ * ```
+ */
 // Format feedback message for deny action
 export const formatFeedbackMessage = (
     comments: Map<number, FeedbackEntry>,
@@ -56,6 +89,10 @@ export const formatFeedbackMessage = (
         if (comments.size > 0) holdParts.push('comments');
         if (deletedLines.size > 0) holdParts.push('deletions');
 
+        const semanticLine =
+            holdParts.length > 0
+                ? ` The ${holdParts.join(' and ')} are plan modifications that will be applied when you return to plan mode.`
+                : '';
         const holdLine =
             holdParts.length > 0
                 ? `\nDo not act on the ${holdParts.join(' or ')} below — hold them until the user confirms to proceed.`
@@ -65,8 +102,8 @@ export const formatFeedbackMessage = (
         messageParts.push(
             `<response_instructions>\n` +
                 `Respond with plain text only — this response must not call ExitPlanMode or any other tool.\n` +
-                `The reason: the user needs to read your answers and may ask follow-up questions before deciding to proceed.${holdLine}\n` +
-                `Only call ExitPlanMode after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead")${applyClause}.\n` +
+                `The reason: the questions below are for discussion — the user will read your answers and may ask follow-up questions before deciding whether to proceed with the plan.${semanticLine}${holdLine}\n` +
+                `Only update the plan after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead")${applyClause}.\n` +
                 `</response_instructions>\n\n` +
                 `<questions>\n${questionItems.join('\n')}\n</questions>`,
         );

--- a/app/tests/integration/ui/decision/decision-socket-send.integration.test.tsx
+++ b/app/tests/integration/ui/decision/decision-socket-send.integration.test.tsx
@@ -67,8 +67,8 @@ describe('decision decision-socket-send integration', () => {
         const decision = sendDecisionSpy.mock.calls[0][0] as string;
         const message = sendDecisionSpy.mock.calls[0][1] as string;
         expect(decision).toBe('deny');
-        expect(message).toContain('Comments on the plan:');
-        expect(message).toContain('Line 1: "Line 1"');
+        expect(message).toContain('<comments>');
+        expect(message).toContain('<ref line="1">Line 1</ref>');
         expect(message).toContain('needs more detail');
     });
 
@@ -89,11 +89,11 @@ describe('decision decision-socket-send integration', () => {
         const decision = sendDecisionSpy.mock.calls[0][0] as string;
         const message = sendDecisionSpy.mock.calls[0][1] as string;
         expect(decision).toBe('deny');
-        expect(message).toContain('Questions about the plan:');
-        expect(message).toContain('Line 1: "Step 1"');
+        expect(message).toContain('<questions>');
+        expect(message).toContain('<ref line="1">Step 1</ref>');
         expect(message).toContain('what is the timeline?');
-        expect(message).toContain('Please answer these questions');
-        expect(message).toContain('Do NOT call ExitPlanMode');
+        expect(message).toContain('<response_instructions>');
+        expect(message).toContain('must not call ExitPlanMode');
     });
 
     test('deny with deletion -> sendDecision called with formatted deletions section', async () => {
@@ -112,8 +112,8 @@ describe('decision decision-socket-send integration', () => {
         const decision = sendDecisionSpy.mock.calls[0][0] as string;
         const message = sendDecisionSpy.mock.calls[0][1] as string;
         expect(decision).toBe('deny');
-        expect(message).toContain('Delete lines:');
-        expect(message).toContain('Line 1: "Line 1"');
+        expect(message).toContain('<deletions>');
+        expect(message).toContain('<ref line="1">Line 1</ref>');
     });
 
     test('deny with comment and deletion -> sendDecision message contains both sections', async () => {
@@ -137,9 +137,9 @@ describe('decision decision-socket-send integration', () => {
         const decision = sendDecisionSpy.mock.calls[0][0] as string;
         const message = sendDecisionSpy.mock.calls[0][1] as string;
         expect(decision).toBe('deny');
-        expect(message).toContain('Comments on the plan:');
+        expect(message).toContain('<comments>');
         expect(message).toContain('important note');
-        expect(message).toContain('Delete lines:');
-        expect(message).toContain('Line 2: "Line 2"');
+        expect(message).toContain('<deletions>');
+        expect(message).toContain('<ref line="2">Line 2</ref>');
     });
 });


### PR DESCRIPTION
## Problem

Question deny messages didn't reliably prevent Claude from re-entering plan mode before the user confirmed to proceed. Comments apply automatically on the next plan iteration — questions should not. Claude was sometimes continuing to update the plan instead of waiting for discussion.

The existing instruction was buried mid-sentence after a dash, lacked a causal reason, gave no concrete trigger examples, and didn't mention that accompanying comments/deletions should also be held.

## Changes

### 1. Restructured `<response_instructions>` block in `formatFeedbackMessage()`

* Constraint-first positive framing: "respond with plain text only — this response must not call ExitPlanMode"
* Causal reason: "the user needs to read your answers and may ask follow-up questions before deciding to proceed"
* Conditional hold instruction: only appears when questions are accompanied by comments and/or deletions (e.g., "Do not act on the comments or deletions below — hold them until the user confirms to proceed")
* Concrete trigger examples: "proceed", "continue", "go ahead"

### 2. Converted content sections to XML

Replaced plain-text headers with typed XML wrappers:

```xml
<questions>
  <question>
    <ref line="2">Step 2: Create the API endpoints</ref>
    <feedback>Why REST and not GraphQL here?</feedback>
  </question>
</questions>

<comments>
  <comment>
    <ref line="1">Step 1: Set up the database schema</ref>
    <feedback>Use Postgres not SQLite</feedback>
  </comment>
</comments>

<deletions>
  <deletion>
    <ref line="3">Step 3: Add authentication middleware</ref>
  </deletion>
</deletions>
```

* `<ref line="N">` — line number as attribute, line content as element body (no escaping needed)
* `<feedback>` — the user's question or comment text
* Multi-line items use multiple `<ref>` elements — no range attributes or comma-separated values

## Research basis

* Constraint-first ordering improves compliance 5–7% single-turn, up to 25% multi-turn
* Positive framing ("respond with plain text only") outperforms negative-only ("do NOT call")
* Causal reasoning: Claude generalizes better from rationale than bare rules
* XML: Claude is trained on XML as a structural primitive via its tool-calling format — type disambiguation between `<question>`, `<comment>`, `<deletion>` is unambiguous in a larger prompt context

Closes #59