### PR TITLE
fix(hook): improve question deny instructions and add conditional hold logic

### DIFF
--- a/app/src/utils/feedback/decision.test.ts
+++ b/app/src/utils/feedback/decision.test.ts
@@ -244,10 +244,9 @@ describe('feedback decision', () => {
                 expect(result).toContain('Why this approach?');
                 expect(result).toContain('Line 3: "line 3"');
                 expect(result).toContain('Is this needed?');
-                expect(result).toContain('Do NOT call ExitPlanMode in this response');
-                expect(result).toContain(
-                    'Only call ExitPlanMode again after the user has explicitly asked you to proceed',
-                );
+                expect(result).toContain('must not call ExitPlanMode');
+                expect(result).toContain('questions below are for discussion');
+                expect(result).toContain('Only update the plan after the user explicitly tells you to continue');
                 expect(result).not.toContain('Comments on the plan:');
             });
 
@@ -259,11 +258,9 @@ describe('feedback decision', () => {
 
                 const result = formatFeedbackMessage(comments, questions, deletedLines, contentLines);
 
-                // Questions section should appear before comments section
                 const questionsIndex = result!.indexOf('Questions about the plan:');
                 const commentsIndex = result!.indexOf('Comments on the plan:');
                 expect(questionsIndex).toBeLessThan(commentsIndex);
-                expect(result).toContain('still use the below feedback');
             });
 
             test('includes explicit instructions with questions', () => {
@@ -274,11 +271,66 @@ describe('feedback decision', () => {
 
                 const result = formatFeedbackMessage(comments, questions, deletedLines, contentLines);
 
-                expect(result).toContain('Do NOT call ExitPlanMode in this response');
-                expect(result).toContain(
-                    'Only call ExitPlanMode again after the user has explicitly asked you to proceed',
+                expect(result).toContain('<response_instructions>');
+                expect(result).toContain('must not call ExitPlanMode');
+                expect(result).toContain('Only update the plan after the user explicitly tells you to continue');
+            });
+
+            test('omits hold instruction when questions are present without comments or deletions', () => {
+                const questions = new Map<number, FeedbackEntry>([[0, { text: 'Question', lines: [0] }]]);
+                const contentLines = ['line 1'];
+
+                const result = formatFeedbackMessage(
+                    new Map<number, FeedbackEntry>(),
+                    questions,
+                    new Set(),
+                    contentLines,
                 );
-                expect(result).toContain('still use the below feedback');
+
+                expect(result).not.toContain('Do not act on');
+                expect(result).not.toContain('apply all the feedback below');
+            });
+
+            test('includes hold instruction for comments when questions are present', () => {
+                const comments = new Map<number, FeedbackEntry>([[0, { text: 'Fix this', lines: [0] }]]);
+                const questions = new Map<number, FeedbackEntry>([[1, { text: 'Why?', lines: [1] }]]);
+                const contentLines = ['line 1', 'line 2'];
+
+                const result = formatFeedbackMessage(comments, questions, new Set(), contentLines);
+
+                expect(result).toContain('comments are plan modifications');
+                expect(result).toContain('Do not act on the comments below');
+                expect(result).toContain('apply all the feedback below');
+                expect(result).not.toContain('Do not act on the deletions below');
+            });
+
+            test('includes hold instruction for deletions when questions are present', () => {
+                const questions = new Map<number, FeedbackEntry>([[0, { text: 'Why?', lines: [0] }]]);
+                const contentLines = ['line 1', 'line 2'];
+
+                const result = formatFeedbackMessage(
+                    new Map<number, FeedbackEntry>(),
+                    questions,
+                    new Set([1]),
+                    contentLines,
+                );
+
+                expect(result).toContain('deletions are plan modifications');
+                expect(result).toContain('Do not act on the deletions below');
+                expect(result).toContain('apply all the feedback below');
+                expect(result).not.toContain('Do not act on the comments below');
+            });
+
+            test('includes hold instruction for comments and deletions when all three are present', () => {
+                const comments = new Map<number, FeedbackEntry>([[0, { text: 'Fix this', lines: [0] }]]);
+                const questions = new Map<number, FeedbackEntry>([[1, { text: 'Why?', lines: [1] }]]);
+                const contentLines = ['line 1', 'line 2', 'line 3'];
+
+                const result = formatFeedbackMessage(comments, questions, new Set([2]), contentLines);
+
+                expect(result).toContain('comments and deletions are plan modifications');
+                expect(result).toContain('Do not act on the comments or deletions below');
+                expect(result).toContain('apply all the feedback below');
             });
         });
 

--- a/app/src/utils/feedback/decision.ts
+++ b/app/src/utils/feedback/decision.ts
@@ -55,13 +55,27 @@ export const formatFeedbackMessage = (
             }
         });
 
+        const holdParts: string[] = [];
+        if (comments.size > 0) holdParts.push('comments');
+        if (deletedLines.size > 0) holdParts.push('deletions');
+
+        const semanticLine =
+            holdParts.length > 0
+                ? ` The ${holdParts.join(' and ')} are plan modifications that will be applied when you return to plan mode.`
+                : '';
+        const holdLine =
+            holdParts.length > 0
+                ? `\nDo not act on the ${holdParts.join(' or ')} below — hold them until the user confirms to proceed.`
+                : '';
+        const applyClause = holdParts.length > 0 ? ` — and when you do, apply all the feedback below` : '';
+
         messageParts.push(
-            `Questions about the plan:\n${questionBlocks.join('\n')}\n\n` +
-                `Please answer these questions. Do NOT call ExitPlanMode in this response — ` +
-                `just answer the questions with plain text and stop. ` +
-                `The user will read your answers and reply in chat. ` +
-                `Only call ExitPlanMode again after the user has explicitly asked you to proceed. ` +
-                `When you return to plan mode, still use the below feedback.`,
+            `<response_instructions>\n` +
+                `Respond with plain text only — this response must not call ExitPlanMode or any other tool.\n` +
+                `The reason: the questions below are for discussion — the user will read your answers and may ask follow-up questions before deciding whether to proceed with the plan.${semanticLine}${holdLine}\n` +
+                `Only update the plan after the user explicitly tells you to continue (e.g., "proceed", "continue", "go ahead")${applyClause}.\n` +
+                `</response_instructions>\n\n` +
+                `Questions about the plan:\n${questionBlocks.join('\n')}`,
         );
     }
 

--- a/app/src/utils/feedback/decision.ts
+++ b/app/src/utils/feedback/decision.ts
@@ -28,6 +28,38 @@ export const sendDecisionViaSocket = (
     }
 };
 
+/**
+ * Formats a deny message from the user's feedback to send back to Claude.
+ *
+ * When questions are present, prepends a `<response_instructions>` block telling
+ * Claude to answer conversationally and wait for the user before updating the plan.
+ * When questions are mixed with comments or deletions, adds a hold instruction so
+ * Claude doesn't act on them until the user confirms to proceed.
+ *
+ * @example
+ * ```
+ * <response_instructions>
+ * Respond with plain text only — this response must not call ExitPlanMode or any other tool.
+ * The reason: the questions below are for discussion — the user will read your answers and may
+ * ask follow-up questions before deciding whether to proceed with the plan. The comments and
+ * deletions are plan modifications that will be applied when you return to plan mode.
+ * Do not act on the comments or deletions below — hold them until the user confirms to proceed.
+ * Only update the plan after the user explicitly tells you to continue (e.g., "proceed",
+ * "continue", "go ahead") — and when you do, apply all the feedback below.
+ * </response_instructions>
+ *
+ * Questions about the plan:
+ * Line 2: "Step 2: Create the API endpoints"
+ * Why REST and not GraphQL here?
+ *
+ * Comments on the plan:
+ * Line 1: "Step 1: Set up the database schema"
+ * Use Postgres not SQLite
+ *
+ * Delete lines:
+ * Line 3: "Step 3: Add authentication middleware"
+ * ```
+ */
 // Format feedback message for deny action
 export const formatFeedbackMessage = (
     comments: Map<number, FeedbackEntry>,

--- a/app/tests/integration/ui/decision/decision-socket-send.integration.test.tsx
+++ b/app/tests/integration/ui/decision/decision-socket-send.integration.test.tsx
@@ -92,8 +92,8 @@ describe('decision decision-socket-send integration', () => {
         expect(message).toContain('Questions about the plan:');
         expect(message).toContain('Line 1: "Step 1"');
         expect(message).toContain('what is the timeline?');
-        expect(message).toContain('Please answer these questions');
-        expect(message).toContain('Do NOT call ExitPlanMode');
+        expect(message).toContain('<response_instructions>');
+        expect(message).toContain('must not call ExitPlanMode');
     });
 
     test('deny with deletion -> sendDecision called with formatted deletions section', async () => {


### PR DESCRIPTION
## Problem

Question deny messages didn't reliably prevent Claude from re-entering plan mode before the user confirmed to proceed. The existing instruction was buried mid-sentence after a dash, lacked a causal reason, gave no concrete trigger examples, and didn't mention that accompanying comments/deletions should also be held.

## Changes

### 1. Restructured `<response_instructions>` block in `formatFeedbackMessage()`

* Constraint-first positive framing: "respond with plain text only — this response must not call ExitPlanMode"
* Causal reason: "the user needs to read your answers and may ask follow-up questions before deciding to proceed"
* Conditional hold instruction: only appears when questions are accompanied by comments and/or deletions (e.g., "Do not act on the comments or deletions below — hold them until the user confirms to proceed")
* Concrete trigger examples: "proceed", "continue", "go ahead"

### 2. Content format unchanged

The plain-text format for refs (`Line N: "content"`) is preserved — this PR isolates the behavioral fix from any structural format changes.

## Why not the full PR #60?

PR #60 bundles this behavioral fix with an XML format migration for all feedback content. The XML change is harder to regression-test (requires live Claude interaction to verify parsing). This PR ships the behavioral fix first so it can be validated independently.

## Test plan

* New unit tests verify the conditional hold instruction appears/is absent based on whether questions are mixed with comments/deletions
* Existing tests updated to match new instruction wording
* All unit and integration tests pass

Closes #59