### PR TITLE
fix(plugin): fall back to compctl when compinit is not loaded

### DIFF
--- a/app/src/commands/completions.test.ts
+++ b/app/src/commands/completions.test.ts
@@ -109,6 +109,18 @@ describe('commands completions', () => {
             run(['zsh']);
             expect(output()).toContain('compdef _planderson planderson');
         });
+
+        test('falls back to compctl when compdef is unavailable', () => {
+            run(['zsh']);
+            const out = output();
+            expect(out).toContain('compctl -k');
+            expect(out).toContain('planderson');
+        });
+
+        test('checks for compdef availability', () => {
+            run(['zsh']);
+            expect(output()).toContain('$+functions[compdef]');
+        });
     });
 
     describe('installation hint', () => {

--- a/app/src/commands/completions.ts
+++ b/app/src/commands/completions.ts
@@ -5,21 +5,25 @@ export const BASH_SCRIPT = `_planderson_complete() {
 complete -F _planderson_complete planderson`;
 
 export const ZSH_SCRIPT = `#compdef planderson
-_planderson() {
-    local -a commands
-    commands=(
-        'help:Show help and keybindings'
-        'hook:Process plan events from Claude Code hooks'
-        'settings:View and update settings'
-        'setup:Interactive onboarding and configuration'
-        'tui:Launch the plan viewer TUI'
-        'tmux:Replace current pane with TUI and restore on exit'
-        'upgrade:Upgrade planderson to the latest version'
-        'completions:Output shell completion script'
-    )
-    _describe 'command' commands
-}
-compdef _planderson planderson`;
+if (( $+functions[compdef] )); then
+    _planderson() {
+        local -a commands
+        commands=(
+            'help:Show help and keybindings'
+            'hook:Process plan events from Claude Code hooks'
+            'settings:View and update settings'
+            'setup:Interactive onboarding and configuration'
+            'tui:Launch the plan viewer TUI'
+            'tmux:Replace current pane with TUI and restore on exit'
+            'upgrade:Upgrade planderson to the latest version'
+            'completions:Output shell completion script'
+        )
+        _describe 'command' commands
+    }
+    compdef _planderson planderson
+else
+    compctl -k "(help hook settings setup tui tmux upgrade completions)" planderson
+fi`;
 
 export const detectShell = (): 'bash' | 'zsh' | null => {
     const shell = process.env.SHELL ?? '';


### PR DESCRIPTION
## Summary
* Zsh completion script assumed `compdef`/`_describe` were available, which requires `compinit`
* Many setups (e.g., only `bashcompinit` loaded) don't have these functions
* Falls back to the always-available `compctl` builtin when `compdef` is absent

## Test plan
* [x] Verified bash completions still work
* [x] Verified zsh completions work without `compinit` (compctl fallback)
* [x] Verified zsh completions work with `compinit` (compdef/\_describe primary path)
* [x] All 1671 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)