### PR TITLE
fix(markdown): require word boundaries for underscore emphasis

### DIFF
--- a/app/src/utils/rendering/markdown/markdown.test.ts
+++ b/app/src/utils/rendering/markdown/markdown.test.ts
@@ -54,6 +54,43 @@ describe('markdown markdown', () => {
             });
         });
 
+        test('parses italic with _ when space-bounded', () => {
+            const result = parseMarkdownLine('word _italic_ word');
+            expect(result).toEqual({
+                type: 'normal',
+                segments: [{ text: 'word ' }, { text: 'italic', italic: true }, { text: ' word' }],
+            });
+        });
+
+        test('parses bold with __ when space-bounded', () => {
+            const result = parseMarkdownLine('word __bold__ word');
+            expect(result).toEqual({
+                type: 'normal',
+                segments: [{ text: 'word ' }, { text: 'bold', bold: true }, { text: ' word' }],
+            });
+        });
+
+        test.each([
+            ['single snake_case', 'foo_bar_baz'],
+            ['many underscores', 'multiple_snake_case_words'],
+            ['mixed boundary start', '_foo_bar'],
+            ['mixed boundary end', 'foo_bar_'],
+        ])('does not italicize mid-word underscores: %s', (_, input) => {
+            const result = parseMarkdownLine(input);
+            expect(result).toEqual({
+                type: 'normal',
+                segments: [{ text: input }],
+            });
+        });
+
+        test('does not bold mid-word double underscores', () => {
+            const result = parseMarkdownLine('foo__bar__baz');
+            expect(result).toEqual({
+                type: 'normal',
+                segments: [{ text: 'foo__bar__baz' }],
+            });
+        });
+
         test('parses inline code with backticks', () => {
             const result = parseMarkdownLine('Use `code` here');
             expect(result).toEqual({

--- a/app/src/utils/rendering/markdown/markdown.ts
+++ b/app/src/utils/rendering/markdown/markdown.ts
@@ -51,7 +51,7 @@ const parseInlineFormatting = (text: string): TextSegment[] => {
         },
         // Bold with __ (supports nesting) - must check before single _
         {
-            regex: /__(.+?)__/g,
+            regex: /(?<=^|\W)__(.+?)__(?=$|\W)/g,
             process: (match) => {
                 return { text: match[1], bold: true, _isNested: true } as TextSegment & { _isNested: boolean };
             },
@@ -65,7 +65,7 @@ const parseInlineFormatting = (text: string): TextSegment[] => {
         },
         // Italic with _ (supports nesting) - use negative lookahead/behind to avoid matching __
         {
-            regex: /(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g,
+            regex: /(?<=^|\W)(?<!_)_(?!_)(.+?)(?<!_)_(?!_)(?=$|\W)/g,
             process: (match) => {
                 return { text: match[1], italic: true, _isNested: true } as TextSegment & { _isNested: boolean };
             },


### PR DESCRIPTION
## Summary

* Underscore emphasis (`_italic_`, `__bold__`) now requires word boundaries around delimiters, matching CommonMark/GFM behavior
* Prevents snake_case identifiers like `foo_bar_baz` from being incorrectly rendered as italic
* Added 7 test cases covering snake_case, mixed boundaries, and space-bounded emphasis

Closes #62

## Test plan

* [x] `foo_bar_baz` renders as plain text
* [x] `foo__bar__baz` renders as plain text
* [x] `_italic_` and `__bold__` still work standalone and space-bounded
* [x] Mixed boundary cases (`_foo_bar`, `foo_bar_`) render as plain text
* [x] All 1353 unit tests pass
* [x] All 303 integration tests pass
* [x] Formatting, linting, type checks, and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)