### PR TITLE
fix(plugin): suppress install script output during upgrade

### DIFF
--- a/app/src/commands/upgrade.test.ts
+++ b/app/src/commands/upgrade.test.ts
@@ -198,15 +198,21 @@ describe('commands upgrade', () => {
     describe('runUpgrade', () => {
         let consoleLogs: string[];
         let consoleWarns: string[];
+        let consoleErrors: string[];
         let originalConsoleLog: typeof console.log;
         let originalConsoleWarn: typeof console.warn;
+        let originalConsoleError: typeof console.error;
+        let originalFetch: typeof globalThis.fetch;
         let originalProcessExit: typeof process.exit;
 
         beforeEach(() => {
             consoleLogs = [];
             consoleWarns = [];
+            consoleErrors = [];
             originalConsoleLog = console.log;
             originalConsoleWarn = console.warn;
+            originalConsoleError = console.error;
+            originalFetch = globalThis.fetch;
             originalProcessExit = process.exit;
 
             console.log = (msg: string) => {
@@ -214,6 +220,9 @@ describe('commands upgrade', () => {
             };
             console.warn = (msg: string) => {
                 consoleWarns.push(msg);
+            };
+            console.error = (msg: string) => {
+                consoleErrors.push(msg);
             };
             process.exit = mock(() => {
                 throw new Error('process.exit called');
@@ -223,6 +232,8 @@ describe('commands upgrade', () => {
         afterEach(() => {
             console.log = originalConsoleLog;
             console.warn = originalConsoleWarn;
+            console.error = originalConsoleError;
+            globalThis.fetch = originalFetch;
             process.exit = originalProcessExit;
             mock.restore();
         });
@@ -285,6 +296,91 @@ describe('commands upgrade', () => {
             }
 
             expect(consoleLogs.some((l) => l.includes('planderson settings --autoUpgrade always'))).toBe(false);
+        });
+
+        type Listener = (...args: unknown[]) => void;
+        const createMockChild = (exitCode: number, stdoutData?: string, stderrData?: string) => {
+            const stdoutListeners: Record<string, Listener[]> = {};
+            const stderrListeners: Record<string, Listener[]> = {};
+            const stdout = {
+                on(event: string, cb: Listener) {
+                    (stdoutListeners[event] ??= []).push(cb);
+                },
+            };
+            const stderr = {
+                on(event: string, cb: Listener) {
+                    (stderrListeners[event] ??= []).push(cb);
+                },
+            };
+            const child = {
+                stdout,
+                stderr,
+                on(event: string, cb: Listener) {
+                    if (event === 'close') {
+                        if (stdoutData) stdoutListeners['data']?.forEach((l) => l(Buffer.from(stdoutData)));
+                        if (stderrData) stderrListeners['data']?.forEach((l) => l(Buffer.from(stderrData)));
+                        cb(exitCode);
+                    }
+                },
+            };
+            return child;
+        };
+
+        const setupNewerVersionMocks = () => {
+            const tempDir = useTempDir();
+            spyOn(os, 'homedir').mockReturnValue(tempDir);
+            globalThis.fetch = mock(() =>
+                Promise.resolve({
+                    url: 'https://github.com/bradleyoesch/planderson/releases/tag/v99.0.0',
+                } as Response),
+            ) as unknown as typeof fetch;
+            spyOn(settingsModule, 'loadSettings').mockReturnValue(DEFAULT_SETTINGS);
+        };
+
+        test('prints "Updated successfully." on successful install', async () => {
+            setupNewerVersionMocks();
+            const mockChild = createMockChild(0, 'Installing planderson...\nINSTALL COMPLETE\n');
+            spyOn(childProcess, 'spawn').mockReturnValue(mockChild as unknown as ReturnType<typeof childProcess.spawn>);
+
+            await runUpgrade();
+
+            expect(consoleLogs.some((l) => l.includes('Updated successfully.'))).toBe(true);
+        });
+
+        test('does not print install script output on success', async () => {
+            setupNewerVersionMocks();
+            const mockChild = createMockChild(0, 'Installing planderson...\nINSTALL COMPLETE\n');
+            spyOn(childProcess, 'spawn').mockReturnValue(mockChild as unknown as ReturnType<typeof childProcess.spawn>);
+
+            await runUpgrade();
+
+            expect(consoleLogs.some((l) => l.includes('Installing planderson'))).toBe(false);
+            expect(consoleLogs.some((l) => l.includes('INSTALL COMPLETE'))).toBe(false);
+        });
+
+        test('prints releases link on successful install', async () => {
+            setupNewerVersionMocks();
+            const mockChild = createMockChild(0);
+            spyOn(childProcess, 'spawn').mockReturnValue(mockChild as unknown as ReturnType<typeof childProcess.spawn>);
+
+            await runUpgrade();
+
+            expect(consoleLogs.some((l) => l.includes(RELEASES_URL))).toBe(true);
+        });
+
+        test('prints full output and "Upgrade failed." on failed install', async () => {
+            setupNewerVersionMocks();
+            const installOutput = 'Installing planderson...\nChecksum verification failed!';
+            const mockChild = createMockChild(1, installOutput, 'some error');
+            spyOn(childProcess, 'spawn').mockReturnValue(mockChild as unknown as ReturnType<typeof childProcess.spawn>);
+
+            process.exit = mock(() => {}) as unknown as typeof process.exit;
+
+            await runUpgrade();
+
+            expect(consoleErrors.some((l) => l.includes(installOutput))).toBe(true);
+            expect(consoleErrors.some((l) => l.includes('Upgrade failed.'))).toBe(true);
+            expect(process.exit).toHaveBeenCalledWith(1);
         });
     });
 });

--- a/app/src/commands/upgrade.ts
+++ b/app/src/commands/upgrade.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from 'child_process';
+import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -95,7 +95,25 @@ export const runUpgrade = async (): Promise<void> => {
     } else {
         console.log(`Updating planderson v${version} → v${latest}...`);
     }
-    spawnSync('bash', ['-c', `curl -fsSL ${INSTALL_URL} | bash`], { stdio: 'inherit' });
+    const success = await new Promise<boolean>((resolve) => {
+        const child = spawn('bash', ['-c', `curl -fsSL ${INSTALL_URL} | bash`], { stdio: 'pipe' });
+        const chunks: Buffer[] = [];
+        child.stdout.on('data', (data: Buffer) => chunks.push(data));
+        child.stderr.on('data', (data: Buffer) => chunks.push(data));
+        child.on('close', (code) => {
+            if (code !== 0) {
+                const output = Buffer.concat(chunks).toString();
+                if (output) console.error(output);
+                console.error('Upgrade failed.');
+            }
+            resolve(code === 0);
+        });
+    });
+    if (!success) {
+        process.exit(1);
+        return;
+    }
     regenerateCompletions();
+    console.log('Updated successfully.');
     console.log(`Releases: ${RELEASES_URL}`);
 };


### PR DESCRIPTION
## Summary

* Capture install.sh output during `planderson upgrade` instead of passing it through with `stdio: 'inherit'`
* On success, show only "Updated successfully." and the releases link
* On failure, dump the full captured output for debugging

Closes #66

## Test plan

* [x] Unit tests for success path (prints "Updated successfully.", suppresses install output, shows releases link)
* [x] Unit test for failure path (prints full output, prints "Upgrade failed.", exits with code 1)
* [x] Existing "already on latest" tests still pass
* [x] Lint and type-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)